### PR TITLE
Fix issue #74: Include model_path in /meta endpoint response

### DIFF
--- a/meta.py
+++ b/meta.py
@@ -11,6 +11,7 @@ class Meta:
         use_sentence_transformer_vectorizer: bool,
         trust_remote_code: bool,
     ):
+        self.model_path = model_path
         if use_sentence_transformer_vectorizer:
             if os.path.exists(f"{model_path}/model_config"):
                 with open(f"{model_path}/model_config", "r") as f:
@@ -23,7 +24,11 @@ class Meta:
             ).to_dict()
 
     def get(self):
-        return {"model": self.config}
+        return {"model": self.config,
+                "model_path": self.model_path,
+        }
+    
+    
 
     def get_model_type(self):
         return self.config["model_type"]


### PR DESCRIPTION
I updated the Meta.get() method in meta.py to include the model_path in the response. This makes it easy to find where the model is stored, especially in setups where file paths might be unclear.

The model_name was already included in the response, so I did not add it again. Adding only the model_path keeps the response clear and avoids repeating the same information. 


@CaseyHaralson, I hope this addresses your request.