### PR TITLE
model2vec support

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -115,12 +115,15 @@ jobs:
             onnx_runtime: false
           - model_name: minishlab/potion-base-32M
             model_tag_name: minishlab/potion-base-32M
+            use_sentence_transformers_vectorizer: true
             onnx_runtime: false
           - model_name: minishlab/potion-base-8M
             model_tag_name: minishlab/potion-base-8M
+            use_sentence_transformers_vectorizer: true
             onnx_runtime: false
           - model_name: minishlab/potion-base-4M
             model_tag_name: minishlab/potion-base-4M
+            use_sentence_transformers_vectorizer: true
             onnx_runtime: false
           - model_name: Snowflake/snowflake-arctic-embed-s
             model_tag_name: snowflake-snowflake-arctic-embed-s

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -113,6 +113,15 @@ jobs:
           - model_name: Snowflake/snowflake-arctic-embed-s
             model_tag_name: snowflake-snowflake-arctic-embed-s
             onnx_runtime: false
+          - model_name: minishlab/potion-base-32M
+            model_tag_name: minishlab/potion-base-32M
+            onnx_runtime: false
+          - model_name: minishlab/potion-base-8M
+            model_tag_name: minishlab/potion-base-8M
+            onnx_runtime: false
+          - model_name: minishlab/potion-base-4M
+            model_tag_name: minishlab/potion-base-4M
+            onnx_runtime: false
           - model_name: Snowflake/snowflake-arctic-embed-s
             model_tag_name: snowflake-snowflake-arctic-embed-s
             onnx_runtime: true

--- a/app.py
+++ b/app.py
@@ -142,6 +142,11 @@ async def lifespan(app: FastAPI):
         use_sentence_transformers_vectorizer,
         trust_remote_code,
     )
+
+    if cuda_support is False and meta_config.get_model_type() == "model2vec":
+        # in case of CPU we need to run this model explicitly on CPU device, not MPS device
+        cuda_core = "cpu"
+
     vec = Vectorizer(
         model_dir,
         cuda_support,

--- a/download.py
+++ b/download.py
@@ -115,7 +115,9 @@ def download_model(model_name: str, model_dir: str, trust_remote_code: bool = Fa
         f"Downloading model {model_name} from huggingface model hub ({trust_remote_code=})"
     )
     try:
-        config = AutoConfig.from_pretrained(model_name, trust_remote_code=trust_remote_code)
+        config = AutoConfig.from_pretrained(
+            model_name, trust_remote_code=trust_remote_code
+        )
         config_dict = config.to_dict()
         model_type = config.to_dict()["model_type"]
     except ValueError as e:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,11 +1,11 @@
-transformers==4.47.1
-fastapi==0.115.6
+transformers==4.48.2
+fastapi==0.115.8
 uvicorn==0.34.0
 nltk==3.9.1
-torch==2.5.1
+torch==2.6.0
 sentencepiece==0.2.0
-sentence-transformers==3.1.1
-optimum==1.23.3
+sentence-transformers==3.4.1
+optimum==1.24.0
 onnxruntime==1.20.1
 onnx==1.17.0
 numpy==1.26.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-transformers==4.47.1
+transformers==4.48.1
 fastapi==0.115.6
 uvicorn==0.34.0
 nltk==3.9.1
 torch==2.5.1
 sentencepiece==0.2.0
-sentence-transformers==3.1.1
+sentence-transformers==3.4.1
 optimum==1.23.3
 onnxruntime==1.20.1
 onnx==1.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-transformers==4.48.1
-fastapi==0.115.6
+transformers==4.48.2
+fastapi==0.115.8
 uvicorn==0.34.0
 nltk==3.9.1
-torch==2.5.1
+torch==2.6.0
 sentencepiece==0.2.0
 sentence-transformers==3.4.1
-optimum==1.23.3
+optimum==1.24.0
 onnxruntime==1.20.1
 onnx==1.17.0
 numpy==1.26.4

--- a/vectorizer.py
+++ b/vectorizer.py
@@ -82,7 +82,7 @@ class Vectorizer:
         if onnx_runtime:
             self.vectorizer = ONNXVectorizer(model_path, trust_remote_code)
         else:
-            if model_type == "t5" or use_sentence_transformers_vectorizer:
+            if model_type == "t5" or "model2vec" or use_sentence_transformers_vectorizer:
                 self.vectorizer = SentenceTransformerVectorizer(
                     model_path,
                     model_name,

--- a/vectorizer.py
+++ b/vectorizer.py
@@ -82,7 +82,7 @@ class Vectorizer:
         if onnx_runtime:
             self.vectorizer = ONNXVectorizer(model_path, trust_remote_code)
         else:
-            if model_type == "t5" or "model2vec" or use_sentence_transformers_vectorizer:
+            if model_type == "t5" or use_sentence_transformers_vectorizer:
                 self.vectorizer = SentenceTransformerVectorizer(
                     model_path,
                     model_name,


### PR DESCRIPTION
Sentence transformers has released model2vec compatibility https://github.com/UKPLab/sentence-transformers/releases/tag/v3.4.1.

This PR adds support for model2vec models such as https://huggingface.co/minishlab/potion-base-8M.

Note that currently transformers does not support `AutoConfig` with model2vec so I am handling the error in this case.