### PR TITLE
Add support for intfloat/multilingual-e5-large model

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -158,6 +158,10 @@ jobs:
             model_tag_name: eurobert-eurobert-2.1b
             trust_remote_code: true
             onnx_runtime: false
+          - model_name: intfloat/multilingual-e5-large
+            model_tag_name: intfloat-multilingual-e5-large
+            use_sentence_transformers_vectorizer: true
+            use_query_passage_prefixes: true
     env:
       LOCAL_REPO: transformers-inference
       REMOTE_REPO: semitechnologies/transformers-inference
@@ -165,6 +169,7 @@ jobs:
       MODEL_TAG_NAME: ${{matrix.model_tag_name}}
       ONNX_RUNTIME: ${{matrix.onnx_runtime}}
       USE_SENTENCE_TRANSFORMERS_VECTORIZER: ${{matrix.use_sentence_transformers_vectorizer}}
+      USE_QUERY_PASSAGE_PREFIXES: ${{matrix.use_query_passage_prefixes}}
       TRUST_REMOTE_CODE: ${{matrix.trust_remote_code}}
     steps:
       - uses: actions/checkout@v3

--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from typing import Union
 from config import (
     TRUST_REMOTE_CODE,
+    USE_QUERY_PASSAGE_PREFIXES,
     get_allowed_tokens,
     get_use_sentence_transformers_multi_process,
     get_t2v_transformers_direct_tokenize,
@@ -78,6 +79,13 @@ async def lifespan(app: FastAPI):
                 return trust_remote_code == "true"
         return TRUST_REMOTE_CODE
 
+    def get_use_query_passage_prefixes() -> bool:
+        if os.path.exists(f"{model_dir}/use_query_passage_prefixes"):
+            with open(f"{model_dir}/use_query_passage_prefixes", "r") as f:
+                use_query_passage_prefixes = f.read()
+                return use_query_passage_prefixes == "true"
+        return USE_QUERY_PASSAGE_PREFIXES
+
     def log_info_about_onnx(onnx_runtime: bool):
         if onnx_runtime:
             onnx_quantization_info = "missing"
@@ -91,6 +99,7 @@ async def lifespan(app: FastAPI):
     model_name, use_sentence_transformers_vectorizer = get_model_name()
     onnx_runtime = get_onnx_runtime()
     trust_remote_code = get_trust_remote_code()
+    use_query_passage_prefixes = get_use_query_passage_prefixes()
 
     cuda_env = os.getenv("ENABLE_CUDA")
     cuda_per_process_memory_fraction = 1.0
@@ -158,6 +167,7 @@ async def lifespan(app: FastAPI):
         onnx_runtime,
         use_sentence_transformers_vectorizer,
         use_sentence_transformers_multi_process,
+        use_query_passage_prefixes,
         model_name,
         trust_remote_code,
         available_workers,

--- a/cicd/build.sh
+++ b/cicd/build.sh
@@ -7,10 +7,12 @@ model_name=${MODEL_NAME?Variable MODEL_NAME is required}
 onnx_runtime=${ONNX_RUNTIME?Variable ONNX_RUNTIME is required}
 trust_remote_code=${TRUST_REMOTE_CODE:-false}
 use_sentence_transformers_vectorizer=${USE_SENTENCE_TRANSFORMERS_VECTORIZER:-false}
+use_query_passage_prefixes=${USE_QUERY_PASSAGE_PREFIXES:-false}
 
 docker build \
   --build-arg "MODEL_NAME=$model_name" \
   --build-arg "ONNX_RUNTIME=$onnx_runtime" \
   --build-arg "TRUST_REMOTE_CODE=$trust_remote_code" \
   --build-arg "USE_SENTENCE_TRANSFORMERS_VECTORIZER=$use_sentence_transformers_vectorizer" \
+  --build-arg "USE_QUERY_PASSAGE_PREFIXES=$use_query_passage_prefixes" \
   -t "$local_repo" .

--- a/cicd/docker_push.sh
+++ b/cicd/docker_push.sh
@@ -9,6 +9,7 @@ docker_password=${DOCKER_PASSWORD?Variable DOCKER_PASSWORD is required}
 onnx_runtime=${ONNX_RUNTIME?Variable ONNX_RUNTIME is required}
 trust_remote_code=${TRUST_REMOTE_CODE:-false}
 use_sentence_transformers_vectorizer=${USE_SENTENCE_TRANSFORMERS_VECTORIZER:-false}
+use_query_passage_prefixes=${USE_QUERY_PASSAGE_PREFIXES:-false}
 original_model_name=$model_name
 git_tag=$GITHUB_REF_NAME
 
@@ -51,6 +52,7 @@ function push_tag() {
       --build-arg "ONNX_RUNTIME=$onnx_runtime" \
       --build-arg "TRUST_REMOTE_CODE=$trust_remote_code" \
       --build-arg "USE_SENTENCE_TRANSFORMERS_VECTORIZER=$use_sentence_transformers_vectorizer" \
+      --build-arg "USE_QUERY_PASSAGE_PREFIXES=$use_query_passage_prefixes" \
       --push \
       --tag "$tag_git" \
       --tag "$tag_latest" \

--- a/config.py
+++ b/config.py
@@ -3,6 +3,7 @@ from typing import List
 from cachetools import TTLCache
 
 TRUST_REMOTE_CODE = os.getenv("TRUST_REMOTE_CODE", False)
+USE_QUERY_PASSAGE_PREFIXES = os.getenv("USE_QUERY_PASSAGE_PREFIXES", False)
 
 
 def get_allowed_tokens() -> List[str] | None:

--- a/download.py
+++ b/download.py
@@ -21,6 +21,7 @@ nltk_dir = "./nltk_data"
 model_name = os.getenv("MODEL_NAME", None)
 force_automodel = os.getenv("FORCE_AUTOMODEL", False)
 trust_remote_code = os.getenv("TRUST_REMOTE_CODE", False)
+use_query_passage_prefixes = os.getenv("USE_QUERY_PASSAGE_PREFIXES", False)
 if not model_name:
     print("Fatal: MODEL_NAME is required")
     print(
@@ -107,6 +108,10 @@ def download_model(model_name: str, model_dir: str, trust_remote_code: bool = Fa
         with open(f"{model_dir}/trust_remote_code", "w") as f:
             f.write(f"{trust_remote_code}")
 
+    def save_use_query_passage_prefixes(use_query_passage_prefixes: bool):
+        with open(f"{model_dir}/use_query_passage_prefixes", "w") as f:
+            f.write(f"{use_query_passage_prefixes}")
+
     def save_model_config(model_config):
         with open(f"{model_dir}/model_config", "w") as f:
             f.write(json.dumps(model_config))
@@ -163,6 +168,7 @@ def download_model(model_name: str, model_dir: str, trust_remote_code: bool = Fa
         tokenizer.save_pretrained(model_dir)
 
     save_trust_remote_code(trust_remote_code)
+    save_use_query_passage_prefixes(use_query_passage_prefixes)
 
     nltk.download("punkt", download_dir=nltk_dir)
     nltk.download("punkt_tab", download_dir=nltk_dir)

--- a/smoke_test.py
+++ b/smoke_test.py
@@ -3,6 +3,7 @@ import unittest
 import requests
 import threading
 import time
+import random
 
 sentences = [
     "Python is easy to learn.",
@@ -105,10 +106,10 @@ class SmokeTest(unittest.TestCase):
             output_dims=True,
         )
 
-    def _test_vectorizing_sentences(self):
+    def _test_vectorizing_sentences(self, task_type: str = ""):
         for sentence in sentences:
-            self._try_to_vectorize(self.url + "/vectors/", sentence)
-            self._try_to_vectorize(self.url + "/vectors", sentence)
+            self._try_to_vectorize(self.url + "/vectors/", sentence, task_type)
+            self._try_to_vectorize(self.url + "/vectors", sentence, task_type)
 
     def test_vectorizing_sentences_parallel(self):
         start = time.time()
@@ -128,6 +129,35 @@ class SmokeTest(unittest.TestCase):
             self._test_vectorizing_sentences()
         end = time.time()
         print(f"test_vectorizing_sentences took: {end - start}s")
+
+    def test_vectorizing_sentences_with_task_type_parallel(self):
+        start = time.time()
+        threads = []
+        for _ in range(10):
+            t = threading.Thread(
+                target=self._test_vectorizing_sentences(
+                    task_type=random.choice(["query", "passage"])
+                )
+            )
+            threads.append(t)
+            t.start()
+        for t in threads:
+            t.join()
+        end = time.time()
+        print(f"test_vectorizing_sentences_parallel took: {end - start}s")
+
+    def test_vectorizing_with_task_type(self):
+        self._try_to_vectorize(
+            self.url + "/vectors/",
+            "The London Eye is a ferris wheel at the River Thames.",
+            "passage",
+        )
+        self._try_to_vectorize(
+            self.url + "/vectors",
+            "The London Eye is a ferris wheel at the River Thames.",
+            "query",
+            output_dims=True,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR:
- adds support for `intfloat/multilingual-e5-large` model
- adds support for prepending `query` `passage` prefixes to vectorized inputs, this behaviour is controlled using `USE_QUERY_PASSAGE_PREFIXES` environment setting